### PR TITLE
Redis Session Stroage를 이용하여 세션 관리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'java'
-    id 'org.springframework.boot' version '3.0.6'
+    id 'org.springframework.boot' version '2.7.12'
     id 'io.spring.dependency-management' version '1.1.0'
 }
 
@@ -21,6 +21,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
 
     implementation 'org.mindrot:jbcrypt:0.4'
+
+    implementation 'org.springframework.session:spring-session-data-redis'
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/sm/makedelivery/config/RedisConfig.java
+++ b/src/main/java/com/sm/makedelivery/config/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.sm.makedelivery.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.session.data.redis.config.annotation.web.http.EnableRedisHttpSession;
+
+/*
+	@EnableRedisHttpSession
+	기존 서버 세션 저젱소를 사용하지 않고 Redis의 Session Stroage에 Session을 저장합니다.
+	springSessionRepositoryFilter라는 이름의 필터를 스프링빈에 생성합니다.
+	springSessionRepositoryFilter는 HttpSession을 스프링 세션에 의해 지원되는 커스텀 구현체로 바꿔줍니다.
+	이 어노테이션이 붙은 곳에는 레디스가 스프링 세션을 지원합니다.
+ */
+
+@Configuration
+@EnableRedisHttpSession(maxInactiveIntervalInSeconds = 10)
+public class RedisConfig {
+
+	@Bean
+	public RedisConnectionFactory redisConnectionFactory() {
+		return new LettuceConnectionFactory();
+	}
+
+}

--- a/src/main/java/com/sm/makedelivery/service/SessionLoginService.java
+++ b/src/main/java/com/sm/makedelivery/service/SessionLoginService.java
@@ -1,10 +1,21 @@
 package com.sm.makedelivery.service;
 
+import javax.servlet.http.HttpSession;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import jakarta.servlet.http.HttpSession;
 import lombok.RequiredArgsConstructor;
+
+/*
+	SessionLoginService
+	HttpSEssion에 직접 의존하지 않습니다.
+	스프링이 SessionLoginService에 HttpSession 의존성 주입(DI)을 해줍니다.
+	LoginService 인터페이스를 이용해 Session 방식의 LoginService를 구현합니다.
+	SessionLoginService는 singleton scope를 가지며 HttpSession은 session scope를 가집니다.
+	이러한 스코프 차이 때문에 Spring이 HttpSession 인스턴스를 동적 프록시로 생성하여 주입합니다.
+	이러한 기법은 Scoped Proxy라고 합니다.
+ */
 
 @Service
 @Transactional(readOnly = true)
@@ -25,3 +36,10 @@ public class SessionLoginService implements LoginService {
 		session.removeAttribute(USER_ID);
 	}
 }
+
+/*
+	레디스의 키값으로 저장되는 타입입니다.
+	spring:session:sessions:expires (string) 해당 세션의 만료키로 사용합니다.
+	spring:session:expirations (set) expire time에 삭제될 세션 정보를 담고 있습니다.
+	spring:session:sessions (hash) session은 map을 저장소로 사용하기 대문에 이곳에 세션 테이터가 있습니다.
+ */

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -4,6 +4,13 @@ spring:
     driver-class-name: com.mysql.cj.jdbc.Driver
     username: delivery
     password: 0987
+  redis:
+    host: localhost
+    password: 0987
+    port: 6379
+  session:
+    store-type: redis
+
 
 mybatis:
   # mapper가 위치한 경로 설정


### PR DESCRIPTION
* Redis Session Stroge를 이용하여 세션 관리하도록 연동하였습니다.

Redis를 연동하는 전체적인 흐름
@EnableRedisHttpSession

springSessionRepositoryFilter라는 이름의 필터를 스프링빈으로 생성합니다.
springSessionRepositoryFilter 필터는 HttpSession을 스프링세션에 의해 지원되는 커스템 구현체로 바꿔줍니다.
그 다음 RedisConnectionFactory을 생성하여 스프링 세션을 레디스 서버로 연결시킵니다.

This closes #12 