### PR TITLE
[CI/CD] Jenkins로 CI/CD 구축

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -41,3 +41,7 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
+
+springBoot {
+    mainClass.set('com.sm.makedelivery.MakeDeliveryApplication')
+}


### PR DESCRIPTION
mainClass를 찾아내지 못하므로 build.gradle에 추가 설정한다.